### PR TITLE
adding '+ file LICENSE' suppresses one R CMD check nag

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Implements a set of DelayedArray backends for the TileDB
     dense/sparse array storage framework.
 Authors@R:
     c(person("Aaron", "Lun", role=c("aut", "cre"), email="luna@gene.com"))
-License: MIT
+License: MIT + file LICENSE
 Depends:
     DelayedArray
 Imports: 


### PR DESCRIPTION
Tiny change, but one that silences 

```
* checking DESCRIPTION meta-information ... NOTE                         
License components which are templates and need '+ file LICENSE':         
  MIT                                                                               
* checking top-level files ... NOTE                                   
File                                                                          
  LICENSE                                                          
is not mentioned in the DESCRIPTION file.
```

into 

```
* checking ‘build’ directory ... OK
* checking DESCRIPTION meta-information ... OK              
* checking top-level files ... OK                    
* checking for left-over files ... OK 
```

and less line noise is preferable.