### PR TITLE
add BiocParallel to Suggests to be picked up in tests

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^\.travis\.yml$
+^TileDBArray_.*\.tar\.gz$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Suggests:
     knitr,
     rmarkdown,
     BiocStyle,
+    BiocParallel,
     testthat,
     Matrix
 VignetteBuilder: knitr


### PR DESCRIPTION
Special prize of "being way more eagle-eyed than I was last eve" goes to @aaronwolen for pointing to the (err) actual [code snipped in `DelayedArray`](https://github.com/Bioconductor/DelayedArray/blob/2953ef73d0569b76d343f52c9675fa80a0996d2b/R/DelayedMatrix-utils.R#L511-L517)

So we do need the package in `Suggests:` as the checking code will create a temporary library with _just_ the listed packages, and if `BiocParallel` is not in `Suggests:`, it is not in there and it all ends in tears as it did for me.    Adding the `Suggests:` gives everybody a lollipop instead and the caravan moves on.

(Also adding `.Rbuildignore` here because I had it hanging around already; technically it is part of the next PR for Travis CI support once you turn that on pretty-please as per #3.)