### PR TITLE
use updated .travis.yml with bspm-enabled run.sh and extra PPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,41 @@
-# R package check using Docker containers
+# Run Travis CI for R using https://eddelbuettel.github.io/r-travis/
 
-os: linux
-dist: bionic
+language: c
 sudo: required
-services: docker
+dist: bionic
 
-jobs:
-  include:
-    - name: dev
-      env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:bioc"
-
+## Two core settings: BSPM for binary installation where possible, and no
+## installation of 'Suggests:' to keep things lighter.
+##
+## We also add edd/r-4.0 as it contains three binary packages (RcppDate,
+## RcppCCTZ, nanotime) used by the tiledb package. This is optional.
 env:
   global:
-    - DOCKER_OPTS="--rm -ti -v $(pwd):/mnt -w /mnt"
-      R_BLD_OPTS="--no-manual"
-      R_CHK_OPTS="--no-manual"
-      PKG_NAME=$(awk '/Package:/ {print $2}' DESCRIPTION)
-      PKG_VER=$(awk '/Version:/ {print $2}' DESCRIPTION)
-      PKG_TGZ="${PKG_NAME}_${PKG_VER}.tar.gz"
+    - USE_BSPM="true"
+    - _R_CHECK_FORCE_SUGGESTS_="false"
+    - ADDED_PPAS="ppa:edd/r-4.0"
 
+## Install the worker script and use it to set things up
 before_install:
-  - docker pull ${DOCKER_CNTR}
-  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} r -p -e 'sessionInfo()'
+  - curl -OLs https://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
+  - ./run.sh bootstrap
 
+## Take care of dependencies (via remotes::install_deps which feeds into
+## BSPM-enabled install.packages(); also install_all installs Suggests:
+## too, and install_r can install named packages from known repos 
 install:
-  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD build ${R_BLD_OPTS} .
+  - ./run.sh install_deps
 
+## Run tests  
 script:
-  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD check ${R_CHK_OPTS} ${PKG_TGZ}
+  - ./run.sh run_tests
+
+## Dump logs of failed
+after_failure:
+  - ./run.sh dump_logs
 
 notifications:
   email:
     on_success: change
     on_failure: change
+  


### PR DESCRIPTION
Here is the promised PR for converting Travis CI use from the (easy, reliable, fast, but less flexible) Docker-based setup to the (now updated) Travis CI setup which can use BSPM.  That gives us binaries for a speedup, and by relying on Ubuntu binaries also give full system dependency resolution (which RSPM cannot do, but it covers other OSs).  

In its repo, I revamped `run.sh` in the process and it now uses `remotes` to resolves dependencies (so when you add packages it "learns" automatically).  You can also switch between Depends/Imports/LinkingTo (default, via `install_deps`) to "everything" adding Suggests (via `install_all`).  

Adding an explicit updated BioC installer is next. I will probably make that respect an option to flip between release and devel, and I may need to run that by you.  

But what we here is good -- almost as fast as Docker, but way more flexible.   I rebased and squashed, this was eight more commits (and you can see the build history and speed at the Travis site).

Oh, and tiledb still installs from source. I reckon this one is likely to change the most, and and via the (already existing) `install_github` we can also pick branches or commits or ... as needed.