### PR TITLE
Update Travis CI for r-devel and Bioc devel

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,5 @@
 ^\.travis\.yml$
 ^TileDBArray_.*\.tar\.gz$
+^\.travis\.yml.prev$
+^\.travis\.yml.release$
+^scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,27 @@
-# Run Travis CI for R using https://eddelbuettel.github.io/r-travis/
+# Run Travis CI using Rocker Project containers
 
 language: c
 sudo: required
-dist: bionic
+dist: focal
+services: docker
 
-## Two core settings: BSPM for binary installation where possible, and no
-## installation of 'Suggests:' to keep things lighter.
-##
-## We also add edd/r-4.0 as it contains three binary packages (RcppDate,
-## RcppCCTZ, nanotime) used by the tiledb package. This is optional.
+jobs:
+  include:
+    - name: dev
+      env: DOCKER_CNTR="rocker/drd"
+
 env:
   global:
-    - USE_BSPM="true"
-    - _R_CHECK_FORCE_SUGGESTS_="false"
-    - ADDED_PPAS="ppa:edd/r-4.0"
-
-## Install the worker script and use it to set things up
-before_install:
-  - curl -OLs https://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
-  - ./run.sh bootstrap
-
-## Take care of dependencies (via remotes::install_deps which feeds into
-## BSPM-enabled install.packages(); also install_all installs Suggests:
-## too, and install_r can install named packages from known repos 
+    - DOCKER_OPTS="--rm -ti -v $(pwd):/mnt -w /mnt"
+      
 install:
-  - ./run.sh install_deps
+  - docker pull ${DOCKER_CNTR}
 
-## Run tests  
 script:
-  - ./run.sh run_tests
-
-## Dump logs of failed
-after_failure:
-  - ./run.sh dump_logs
+  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} /mnt/scripts/ci.sh
 
 notifications:
   email:
     on_success: change
     on_failure: change
-  
+

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+## -- Env vars to set R for 'R-devel' in container, and no suggested packages
+export RHOME=/usr/local/lib/R
+export _R_CHECK_FORCE_SUGGESTS_=false
+
+## -- Determine current package name and version
+PKG_NAME=$(awk '/Package:/ {print $2}' DESCRIPTION)
+PKG_VER=$(awk '/Version:/ {print $2}' DESCRIPTION)
+PKG_TGZ="${PKG_NAME}_${PKG_VER}.tar.gz"
+
+## -- Update packages and install build dependencies
+apt update -qq
+apt upgrade -q
+apt install -y --no-install-recommends libpcre2-dev liblzma-dev libbz2-dev libicu-dev libblas-dev liblapack-dev
+
+## -- Build littler under r-devel and link it as to /usr/local/bin (shadowing the existing one)
+RDscript -e 'install.packages("littler")'
+ln -sf /usr/local/lib/R/site-library/littler/bin/r /usr/local/bin/r
+
+## -- use littler and littler scripts to install BioConductor development packages
+install.r Rcpp tiledb BiocManager Matrix lattice testthat
+r -l BiocManager -e 'install(version="devel", ask=FALSE, update=TRUE)'
+r -l BiocManager -e 'install(c("DelayedArray", "S4Vectors"), ask=FALSE)'
+
+## -- now that everything is prepared, create a tarball and check it
+RD CMD build --no-manual --no-build-vignettes .
+RD CMD check --no-manual --no-vignettes ${PKG_TGZ}

--- a/src/remap_indices.cpp
+++ b/src/remap_indices.cpp
@@ -4,7 +4,7 @@
 // [[Rcpp::export(rng=false)]]
 Rcpp::List remap_indices(Rcpp::List extracted, Rcpp::List remapping) {
     const size_t n_dims = extracted.size();
-    if (n_dims != remapping.size()) {
+    if (n_dims != static_cast<size_t>(remapping.size())) {
         throw std::runtime_error("'remapping' and 'extracted' should have the same length");
     }
 


### PR DESCRIPTION
With this PR, the Travis CI runs now install "everything" that the TileDBArray needs on fresh [rocker/drd](https://hub.docker.com/r/rocker/drd) containers.  These containers are rebuilt on a weekly schedule (triggering early Sunday) so we should hopefully get reliable R-devel upgrades easily.

The PR also contains a minor bugfix for a `size_t`  cast