### PR TITLE
install nanotime (and its dependencies) as Debian binaries

### DIFF
--- a/scripts/ciRel.sh
+++ b/scripts/ciRel.sh
@@ -12,13 +12,13 @@ PKG_TGZ="${PKG_NAME}_${PKG_VER}.tar.gz"
 ## -- Update packages and install build dependencies
 apt update -qq
 apt upgrade -q -y
-apt install -y --no-install-recommends r-cran-rcpp r-cran-matrix r-cran-lattice r-cran-testthat r-cran-bit64 r-cran-xts
+apt install -y --no-install-recommends r-cran-rcpp r-cran-matrix r-cran-lattice r-cran-testthat r-cran-bit64 r-cran-xts r-cran-nanotime
 
 ## DelayedArray and S4Vectors in R are too old
 install.r BiocManager
 installBioc.r DelayedArray
 
-## -- install tiledb (plus remaining R package dependencies from nanotime)
+## -- install tiledb
 install.r tiledb
 
 ## -- now that everything is prepared, create a tarball and check it


### PR DESCRIPTION
This installs nanotime (and its dependencies RcppDate and RcppCCTZ) as pre-built binaries as these were recently added to Debian as packages.  No functional change for the test over installing them from CRAN, it just saves a few seconds of compilation.