### PR TITLE
Add support for character arrays in TileDBArray

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TileDBArray
-Version: 1.15.4
-Date: 2024-10-01
+Version: 1.15.5
+Date: 2025-04-24
 Title: Using TileDB as a DelayedArray Backend
 Description: Implements a DelayedArray backend for reading and
     writing dense or sparse arrays in the TileDB format. The

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -206,7 +206,7 @@ setMethod("path", "TileDBArraySeed", function(object, ...) {
 
 #' @export
 setMethod("extract_array", "TileDBArraySeed", function(x, index) {
-    fill <- switch(type(x), double=0, integer=0L, logical=FALSE)
+    fill <- switch(type(x), character="", double=0, integer=0L, logical=FALSE)
     d2 <- .get_block_dims(x, index)
 
     # Hack to overcome zero-length indices that cause tiledb to throw.

--- a/R/TileDBRealizationSink.R
+++ b/R/TileDBRealizationSink.R
@@ -151,11 +151,13 @@ TileDBRealizationSink <- function(
         storagetype <- r_to_tiledb_type(vector(type))
     }
 
+    ncells <- if (storagetype %in% c("ASCII", "CHAR", "UTF8")) NA_integer_ else 1L
+
     schema <- tiledb_array_schema(
         ctx=context,
         domain=dom, 
         sparse=sparse,
-        attrs=list(tiledb_attr(ctx=context, attr, type=storagetype)),
+        attrs=list(tiledb_attr(attr, type=storagetype, ncells=ncells, ctx=context)),
         cell_order = cellorder,
         tile_order = tileorder,
         capacity = capacity

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -10,14 +10,17 @@ XD <- as(DD, "TileDBArray")
 DL <- DD > 0
 XL <- as(DL, "TileDBArray")
 
+DC <- matrix(sample(letters, 10000, replace=TRUE), nrow=200)
+XC <- as(DC, "TileDBArray")
+
 SD <- Matrix::rsparsematrix(50, 50, density=0.1)
 YD <- as(SD, "TileDBArray")
 
 SL <- SD > 0
 YL <- as(SL, "TileDBArray")
 
-tdb <- list(XI, XD, XL, YD, YL)
-ref <- list(DI, DD, DL, SD, SL)
+tdb <- list(XI, XD, XL, XC, YD, YL)
+ref <- list(DI, DD, DL, DC, SD, SL)
 
 test_that("basic read operations work correctly ", {
     for (x in seq_along(tdb)) {
@@ -62,6 +65,9 @@ test_that("more complex matrix operations work correctly", {
     for (x in seq_along(tdb)) {
         r <- ref[[x]]
         t <- tdb[[x]]
+
+        if (is.character(r))
+            next
 
         expect_equal(colSums(r), colSums(t))
         expect_equal(rowSums(r), rowSums(t))

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -4,11 +4,12 @@
 DI <- matrix(rpois(10000, 5), nrow=200)
 DD <- matrix(rnorm(10000), nrow=200)
 DL <- DD > 0
+DC <- matrix(sample(letters, 10000, replace=TRUE), nrow=200)
 
 SD <- Matrix::rsparsematrix(50, 50, density=0.1)
 SL <- SD > 0
 
-ref <- list(DI, DD, DL, SD, SL)
+ref <- list(DI, DD, DL, DC, SD, SL)
 
 test_that("writing works as expected", {
     for (x in seq_along(ref)) {


### PR DESCRIPTION
- Add character type handling in extract_array method
- Update TileDBRealizationSink to properly handle character arrays with ncells parameter
- Add character array tests to test-read.R and test-write.R
- Bump version to 1.15.5 and update date